### PR TITLE
Use a conditional symbol instead of `targets.json`

### DIFF
--- a/agent/rpm/pbench-agent.spec.j2
+++ b/agent/rpm/pbench-agent.spec.j2
@@ -19,10 +19,12 @@ Buildarch:      noarch
 Requires:  python39
 # This is used by the shebang processor
 %define __python3 /usr/bin/python3.9
+%define __python_name python39
 
 %else
 
 Requires:  python3
+%define __python_name python3
 
 %endif
 
@@ -34,7 +36,7 @@ Requires:  python3
 
 # RPMs for modules in requirements.txt
 Requires: python3-pip, python3-requests
-#RPMS for module dependencies
+# RPMS for module dependencies
 Requires: python3-psutil
 
 # RHEL7 also does not define __python3 - we need it for installing
@@ -43,18 +45,10 @@ Requires: python3-psutil
 
 %else
 
-{# Jinja2 template for python dependencies - see the targets.json file for the input data #}
-{%for tname, tcond in targets.items() -%}
-
-%if {{ tcond }}
 # RPMs for modules in requirements.txt
-Requires: {{ tname }}-pip, {{ tname }}-cffi, {{ tname }}-requests
-#RPMS for module dependencies
-Requires: {{ tname }}-psutil
-%endif
-
-{% endfor %}
-{# end of template #}
+Requires: %{__python_name}-pip, %{__python_name}-cffi, %{__python_name}-requests
+# RPMS for module dependencies
+Requires: %{__python_name}-psutil
 
 %endif
 

--- a/agent/rpm/targets.json
+++ b/agent/rpm/targets.json
@@ -1,7 +1,0 @@
-{
-    "targets": {
-        "python3": "0%{?rhel} != 8",
-        "python39": "0%{?rhel} == 8"
-    }
-}
-

--- a/utils/rpm.mk
+++ b/utils/rpm.mk
@@ -41,7 +41,7 @@ srpm: spec patches tarball
 .PHONY: spec
 spec: rpm-dirs ${prog}.spec.j2
 	if [ -e ./seqno ] ;then expr ${seqno} + 1 > ./seqno ;fi
-	jinja2 ${prog}.spec.j2 targets.json -D version=${VERSION} -D gdist=g${sha1} -D seqno=${seqno} > ${RPMSPEC}/${prog}.spec
+	jinja2 ${prog}.spec.j2 -D version=${VERSION} -D gdist=g${sha1} -D seqno=${seqno} > ${RPMSPEC}/${prog}.spec
 	cp ${PBENCHTOP}/utils/rpmlint ${RPMSPEC}/pbench-common.rpmlintrc
 	XDG_CONFIG_HOME=${PBENCHTOP}/utils rpmlint ${RPMSPEC}/${prog}.spec
 


### PR DESCRIPTION
This is an alternative to [#2922](https://github.com/distributed-system-analysis/pbench/pull/2922).

Instead of iterating over a list of mutually exclusive conditions, we can simply define a symbol for the name of the Python distribution that we want to reference, and then use that symbol to reference package names.  This frees us from needing the external file and the loop construct.

(Also, fix a couple of omitted spaces.)